### PR TITLE
Cleanup gruntfile

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -48,19 +48,8 @@ module.exports = function(grunt) {
         bump: {
             options: {
                 files: ['package.json', 'bower.json'],
-                updateConfigs: [],
-                commit: true,
-                commitMessage: 'Release v%VERSION%',
                 commitFiles: ['-a'],
-                createTag: true,
-                tagName: 'v%VERSION%',
-                tagMessage: 'Version %VERSION%',
-                push: true,
-                pushTo: 'paradeiser',
-                gitDescribeOptions: '--tags --always --abbrev=1 --dirty=-d',
-                globalReplace: false,
-                prereleaseName: false,
-                regExp: false
+                pushTo: 'paradeiser'
             }
         }
     });


### PR DESCRIPTION
Remove unneeded options of `grunt-bump`.
You don’t need to set options if you use the default values :octocat: 

See https://github.com/vojtajina/grunt-bump#configuration
